### PR TITLE
Fix saving of payment status in sales tracking

### DIFF
--- a/api/src/validators/sales.validator.js
+++ b/api/src/validators/sales.validator.js
@@ -2,7 +2,16 @@ const Joi = require('joi');
 
 const paymentMethods = ['efectivo', 'transferencia', 'credito', 'mixto'];
 // Permitimos estados de flujo y de pago (Pagado/Vencido) para soportar UI actual
-const saleStatuses = ['Activa', 'Pendiente', 'Finalizada', 'Cancelada', 'Pagado', 'Vencido'];
+const saleStatuses = [
+  'Activa',
+  'Pendiente',
+  'Finalizada',
+  'Cancelada',
+  'Pagado',
+  'Vencido',
+  'Debe',
+  'En espera'
+];
 
 const createSaleSchema = Joi.object({
   id_inmueble: Joi.number().integer().required(),

--- a/src/features/dashboard/pages/sales/SalesManagementPage.jsx
+++ b/src/features/dashboard/pages/sales/SalesManagementPage.jsx
@@ -238,11 +238,12 @@ const mapEstadoUiToVentaEstado = (estado = "") => {
 
     .toLowerCase();
 
-  if (normalized === "pagado" || normalized === "completada") return "Finalizada";
-
+  if (normalized === "pagado" || normalized === "completada") return "Pagado";
   if (normalized === "cancelado" || normalized === "cancelada") return "Cancelada";
+  if (normalized === "debe") return "Debe";
+  if (normalized === "en espera") return "En espera";
 
-  // Debe / En espera / Iniciada / En negociación → Activa
+  // Cualquier otro valor se trata como estado de flujo general
 
   return "Activa";
 


### PR DESCRIPTION
## Summary
- preserve payment state values when mapping UI selections to backend payloads
- allow backend validation to accept new payment states for sales updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6940ba6587bc832ca96b8ecee04a058b)